### PR TITLE
fix: distinction between update:layout and layout-updated events

### DIFF
--- a/packages/vue3-drr-grid-layout/src/components/GridLayout/GridLayout.vue
+++ b/packages/vue3-drr-grid-layout/src/components/GridLayout/GridLayout.vue
@@ -170,19 +170,20 @@ const props = defineProps({
 })
 // emits
 const emit = defineEmits([
-  'update:layout',
-  'layout-ready',
-  'update:breakpoint',
-  'layout-created',
-  'layout-before-mount',
-  'layout-mounted',
   'container-resized',
-  'item-resize',
-  'item-resized',
+  'intersection-observe',
+  'intersection-unobserve',
   'item-move',
   'item-moved',
-  'intersection-observe',
-  'intersection-unobserve'
+  'item-resize',
+  'item-resized',
+  'layout-before-mount',
+  'layout-created',
+  'layout-mounted',
+  'layout-ready',
+  'layout-updated',
+  'update:breakpoint',
+  'update:layout'
 ])
 const emitter = mitt<Events>()
 
@@ -401,7 +402,7 @@ const layoutUpdate = (): void => {
 
     updateHeight()
 
-    emit('update:layout', props.layout)
+    emit('layout-updated', props.layout)
     emitter.emit('recalculate-styles')
   }
 }
@@ -524,7 +525,7 @@ const resizeEvent = ([eventName, id, x, y, h, w]: GridLayoutEvent): void => {
   updateHeight()
 
   if (eventName === 'resizeend') {
-    emit('update:layout', props.layout)
+    emit('layout-updated', props.layout)
   }
 }
 
@@ -556,7 +557,7 @@ const dragEvent = ([eventName, id, x, y, h, w]: GridLayoutEvent): void => {
 
   if (eventName === 'dragend') {
     compact(props.layout, props.verticalCompact)
-    emit('update:layout', props.layout)
+    emit('layout-updated', props.layout)
   }
 }
 
@@ -600,7 +601,7 @@ onMounted(() => {
       addWindowEventListener('resize', onWindowResize.bind(this))
       compact(props.layout, props.verticalCompact)
 
-      emit('update:layout', props.layout)
+      emit('layout-updated', props.layout)
       updateHeight()
 
       if (wrapper.value) {


### PR DESCRIPTION
Hi! Thanks for your great work!

I just updated this PR with your most recent changes (and cleaned things that did not belong in here).

I came across the issue, that you don't make a distinction between an ongoing layout change and a finished one [here](https://github.com/melrose13-69/vue3-dragable-grid-layout/blob/dev/packages/vue3-drr-grid-layout/src/components/GridLayout/GridLayout.vue#L550-L559). In both cases the ``update:layout`` event is emitted.

So I gave the second one (in the highlighted lines) a different name and based the naming of the finished event (``layout-updated``) on [the implementation](https://github.com/jbaysolutions/vue-grid-layout/blob/d1a4c4ea0feaacf2835da6d7058bfafdcbc9f577/src/components/GridLayout.vue#L379) of [jbaysolutions](https://github.com/jbaysolutions/vue-grid-layout).

I'm not sure why they used different notations ( "-" vs ":" )...
What do you think?