### PR TITLE
fix memory leak issue

### DIFF
--- a/packages/vue3-drr-grid-layout/src/components/GridItem/GridItem.vue
+++ b/packages/vue3-drr-grid-layout/src/components/GridItem/GridItem.vue
@@ -509,7 +509,7 @@ onBeforeUnmount(() => {
   emitter?.off('set-col-num', setColNum)
 
   if (interactObj.value) {
-    interactObj.value.unset()
+    interact(item.value).unset()
   }
 
   if (props.observer) {

--- a/packages/vue3-drr-grid-layout/src/components/GridItem/GridItem.vue
+++ b/packages/vue3-drr-grid-layout/src/components/GridItem/GridItem.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import { CSSProperties } from 'vue'
+import { CSSProperties, toRaw } from 'vue'
 import { emitterKey } from '../../types/symbols'
 import { getColsFromBreakpoint } from '../../helpers/responsiveUtils'
 import interact from '@interactjs/interactjs'
@@ -509,7 +509,7 @@ onBeforeUnmount(() => {
   emitter?.off('set-col-num', setColNum)
 
   if (interactObj.value) {
-    interact(item.value).unset()
+    toRaw(interactObj.value).unset()
   }
 
   if (props.observer) {

--- a/packages/vue3-drr-grid-layout/src/components/GridLayout/GridLayout.vue
+++ b/packages/vue3-drr-grid-layout/src/components/GridLayout/GridLayout.vue
@@ -204,6 +204,7 @@ const originalLayout = ref(props.layout)
 const placeholder = ref({ h: 0, i: -1, w: 0, x: 0, y: 0 })
 const width = ref(0)
 let observer: IntersectionObserver
+let windowResizeEventWithContext: () => void
 // refs
 const wrapper = ref<HTMLDivElement | null>(null)
 
@@ -496,7 +497,7 @@ const createObserver = () => {
 // lifecycles
 onCreated()
 onBeforeUnmount(() => {
-  removeWindowEventListener('resize', onWindowResize)
+  removeWindowEventListener('resize', windowResizeEventWithContext)
 
   if (erd.value && wrapper.value) {
     erd.value.uninstall(wrapper.value)
@@ -511,6 +512,7 @@ onBeforeMount(() => {
 
 onMounted(() => {
   emit('layout-mounted', props.layout)
+  windowResizeEventWithContext = onWindowResize.bind(this)
   nextTick(() => {
     originalLayout.value = props.layout
 
@@ -518,7 +520,7 @@ onMounted(() => {
       onWindowResize()
       initResponsiveFeatures()
 
-      addWindowEventListener('resize', onWindowResize.bind(this))
+      addWindowEventListener('resize', windowResizeEventWithContext)
       compact(props.layout, props.verticalCompact)
 
       emit('update:layout', props.layout)


### PR DESCRIPTION
Hi, I find some memory leak issue when I removing GridItem or GridLayout component. I see some detached dom in chrome dev tool.

1. When GridItem, which using interactjs, unmounted, calling interactObj.value.unset() is not working. Use interactjs isSet() to check if an element or selector has been set with the interact is still true. I rewrite it as **interact(item.value).unset()**, and it's work.
2. Because onWindowResize event in GridLayout is using bind(this), we should store the closure in a variable, to prevent bind() creating a new reference each time its called.