### PR TITLE
fix: update height bug

### DIFF
--- a/packages/vue-draggable-grid/src/components/GridLayout.vue
+++ b/packages/vue-draggable-grid/src/components/GridLayout.vue
@@ -161,6 +161,9 @@ watch(() => props.layout.length, () => {
 watch(() => props.margin, () => {
   updateHeight()
 })
+watch(() => props.layout, () => {
+  updateHeight()
+})
 watch(() => props.responsive, value => {
   if (!value) {
     emit('update:layout', originalLayout.value)


### PR DESCRIPTION
Fix a bug where the DOM height does not update when the total height (Y) decreases upon layout configuration update.

1. click toggle
2. Pull the scroll bar down
3. You will find that the height is not updated and there is excess height.

[https://codesandbox.io/p/devbox/optimistic-poincare-jc6jrn?file=%2Fpackage.json%3A17%2C21&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522cltjhk4j000073b6hko0a5vqe%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522cltjhk4j000023b6hlake8srj%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522cltjhk4j000043b6hzlq4jfx1%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522cltjhk4j000063b6h3pu06i68%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B51.49868545700326%252C48.50131454299674%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522cltjhk4j000023b6hlake8srj%2522%253A%257B%2522id%2522%253A%2522cltjhk4j000023b6hlake8srj%2522%252C%2522activeTabId%2522%253A%2522cltsa80ds00023b6hd0f2vzpl%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252F.codesandbox%252Ftasks.json%2522%252C%2522id%2522%253A%2522cltjhn5rx00cc3b6h4s77ywh1%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522cltjhqt6d00023b6hzjjueynb%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A46%252C%2522startColumn%2522%253A13%252C%2522endLineNumber%2522%253A46%252C%2522endColumn%2522%253A13%257D%255D%252C%2522filepath%2522%253A%2522%252Fsrc%252FApp.vue%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522cltsa80ds00023b6hd0f2vzpl%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A17%252C%2522startColumn%2522%253A21%252C%2522endLineNumber%2522%253A17%252C%2522endColumn%2522%253A21%257D%255D%252C%2522filepath%2522%253A%2522%252Fpackage.json%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%257D%252C%2522cltjhk4j000063b6h3pu06i68%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cltjhk4j000053b6huedfibvu%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_PORT%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522port%2522%253A5173%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522cltjhk4j000063b6h3pu06i68%2522%252C%2522activeTabId%2522%253A%2522cltjhk4j000053b6huedfibvu%2522%257D%252C%2522cltjhk4j000043b6hzlq4jfx1%2522%253A%257B%2522id%2522%253A%2522cltjhk4j000043b6hzlq4jfx1%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cltjhk4j000033b6h8e4q02by%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522dev%2522%257D%255D%252C%2522activeTabId%2522%253A%2522cltjhk4j000033b6h8e4q02by%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D](url)

